### PR TITLE
Add order history flow and Postman E2E coverage

### DIFF
--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/dto/order/OrderSummaryResponse.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/dto/order/OrderSummaryResponse.java
@@ -1,0 +1,12 @@
+package com.anbu.aipos.adapters.in.web.dto.order;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record OrderSummaryResponse(
+        Long id,
+        BigDecimal totalAmount,
+        String status,
+        Instant createdAt,
+        String createdByUsername
+) {}

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/dto/order/checkout/CheckoutApiResponse.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/dto/order/checkout/CheckoutApiResponse.java
@@ -1,4 +1,4 @@
-package com.anbu.aipos.adapters.in.web.dto.order;
+package com.anbu.aipos.adapters.in.web.dto.order.checkout;
 
 import java.math.BigDecimal;
 import java.util.List;

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/dto/order/checkout/CheckoutMapper.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/dto/order/checkout/CheckoutMapper.java
@@ -1,4 +1,4 @@
-package com.anbu.aipos.adapters.in.web.dto.order;
+package com.anbu.aipos.adapters.in.web.dto.order.checkout;
 
 
 import com.anbu.aipos.core.port.in.order.CheckoutUseCase;

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/dto/order/checkout/CheckoutRequest.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/dto/order/checkout/CheckoutRequest.java
@@ -1,4 +1,4 @@
-package com.anbu.aipos.adapters.in.web.dto.order;
+package com.anbu.aipos.adapters.in.web.dto.order.checkout;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/order/OrderController.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/order/OrderController.java
@@ -1,0 +1,36 @@
+package com.anbu.aipos.adapters.in.web.order;
+
+import com.anbu.aipos.adapters.in.web.dto.order.OrderSummaryResponse;
+import com.anbu.aipos.application.order.OrderQueryService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderQueryService orderQueryService;
+
+    public OrderController(OrderQueryService orderQueryService) {
+        this.orderQueryService = orderQueryService;
+    }
+
+    @GetMapping
+    public Page<OrderSummaryResponse> getOrders(
+            @AuthenticationPrincipal Jwt jwt,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+
+        var tenantId = jwt.getClaimAsString("tenant_id");
+
+        return orderQueryService.getOrders(tenantId, pageable);
+    }
+}

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/order/checkout/CheckoutController.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/order/checkout/CheckoutController.java
@@ -1,8 +1,8 @@
-package com.anbu.aipos.adapters.in.web;
+package com.anbu.aipos.adapters.in.web.order.checkout;
 
-import com.anbu.aipos.adapters.in.web.dto.order.CheckoutApiResponse;
-import com.anbu.aipos.adapters.in.web.dto.order.CheckoutMapper;
-import com.anbu.aipos.adapters.in.web.dto.order.CheckoutRequest;
+import com.anbu.aipos.adapters.in.web.dto.order.checkout.CheckoutApiResponse;
+import com.anbu.aipos.adapters.in.web.dto.order.checkout.CheckoutMapper;
+import com.anbu.aipos.adapters.in.web.dto.order.checkout.CheckoutRequest;
 import com.anbu.aipos.core.port.in.order.CheckoutUseCase;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/product/ProductController.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/product/ProductController.java
@@ -1,4 +1,4 @@
-package com.anbu.aipos.adapters.in.web;
+package com.anbu.aipos.adapters.in.web.product;
 
 import com.anbu.aipos.adapters.in.web.dto.product.CreateProductRequest;
 import com.anbu.aipos.application.product.ProductService;

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/test/CashierController.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/test/CashierController.java
@@ -1,4 +1,4 @@
-package com.anbu.aipos.adapters.in.web;
+package com.anbu.aipos.adapters.in.web.test;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/test/DebugController.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/test/DebugController.java
@@ -1,4 +1,4 @@
-package com.anbu.aipos.adapters.in.web;
+package com.anbu.aipos.adapters.in.web.test;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/test/TenantController.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/test/TenantController.java
@@ -1,4 +1,4 @@
-package com.anbu.aipos.adapters.in.web;
+package com.anbu.aipos.adapters.in.web.test;
 
 import com.anbu.aipos.config.TenantContext;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/user/AdminController.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/user/AdminController.java
@@ -1,4 +1,4 @@
-package com.anbu.aipos.adapters.in.web;
+package com.anbu.aipos.adapters.in.web.user;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/user/AuthController.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/user/AuthController.java
@@ -1,4 +1,4 @@
-package com.anbu.aipos.adapters.in.web;
+package com.anbu.aipos.adapters.in.web.user;
 
 import com.anbu.aipos.adapters.in.web.dto.user.RegisterUserRequest;
 import com.anbu.aipos.adapters.out.keycloak.KeycloakAdminProperties;

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/user/AuthExceptionHandler.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/user/AuthExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.anbu.aipos.adapters.in.web;
+package com.anbu.aipos.adapters.in.web.user;
 
 import java.util.Map;
 import org.springframework.http.HttpStatus;

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/user/RegisterUserResponse.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/user/RegisterUserResponse.java
@@ -1,4 +1,4 @@
-package com.anbu.aipos.adapters.in.web;
+package com.anbu.aipos.adapters.in.web.user;
 
 public record RegisterUserResponse(
         String message,

--- a/backend/src/main/java/com/anbu/aipos/adapters/in/web/user/UserController.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/in/web/user/UserController.java
@@ -1,4 +1,4 @@
-package com.anbu.aipos.adapters.in.web;
+package com.anbu.aipos.adapters.in.web.user;
 
 import com.anbu.aipos.adapters.in.web.dto.user.CreateUserRequest;
 import com.anbu.aipos.application.user.UserService;

--- a/backend/src/main/java/com/anbu/aipos/adapters/out/persistence/order/OrderJpaRepository.java
+++ b/backend/src/main/java/com/anbu/aipos/adapters/out/persistence/order/OrderJpaRepository.java
@@ -1,6 +1,9 @@
 package com.anbu.aipos.adapters.out.persistence.order;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderJpaRepository extends JpaRepository<PosOrderEntity, Long> {
+    Page<PosOrderEntity> findByTenantId(String tenantId, Pageable pageable);
 }

--- a/backend/src/main/java/com/anbu/aipos/application/order/OrderQueryService.java
+++ b/backend/src/main/java/com/anbu/aipos/application/order/OrderQueryService.java
@@ -1,0 +1,29 @@
+package com.anbu.aipos.application.order;
+
+import com.anbu.aipos.adapters.in.web.dto.order.OrderSummaryResponse;
+import com.anbu.aipos.adapters.out.persistence.order.OrderJpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderQueryService {
+
+    private final OrderJpaRepository orderRepository;
+
+    public OrderQueryService(OrderJpaRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    public Page<OrderSummaryResponse> getOrders(String tenantId, Pageable pageable) {
+
+        return orderRepository.findByTenantId(tenantId, pageable)
+                .map(order -> new OrderSummaryResponse(
+                        order.getId(),
+                        order.getTotalAmount(),
+                        order.getStatus(),
+                        order.getCreatedAt(),
+                        order.getCreatedByUsername()
+                ));
+    }
+}

--- a/frontend/apps/pos-app/src/app/app.routes.ts
+++ b/frontend/apps/pos-app/src/app/app.routes.ts
@@ -4,7 +4,7 @@ export const appRoutes: Route[] = [
   {
     path: '',
     pathMatch: 'full',
-    redirectTo: 'dashboard',
+    redirectTo: 'login',
   },
   {
     path: 'login',
@@ -51,6 +51,11 @@ export const appRoutes: Route[] = [
     path: 'checkout',
     loadComponent: () =>
       import('./features/checkout/checkout-page.component').then((m) => m.CheckoutPageComponent),
+  },
+  {
+    path: 'orders',
+    loadComponent: () =>
+      import('./features/orders/orders-page.component').then((m) => m.OrdersPageComponent),
   },
    {
     path: 'pos',

--- a/frontend/apps/pos-app/src/app/app.ts
+++ b/frontend/apps/pos-app/src/app/app.ts
@@ -18,6 +18,7 @@ export class App {
     { label: 'Cart', path: '/cart' , authenticationRequired: true, adminOnly: true},
     { label: 'Checkout', path: '/checkout' , authenticationRequired: true, adminOnly: true},
     { label: 'Order', path: '/pos' , authenticationRequired: true},
+    { label: 'Orders', path: '/orders' , authenticationRequired: true},
     { label: 'AI Assistant', path: '/ai-assistant' , authenticationRequired: true},
     { label: 'Login', path: '/login' , authenticationRequired: false},
     { label: 'Register', path: '/register' , authenticationRequired: false},

--- a/frontend/apps/pos-app/src/app/core/api/pos-api.service.ts
+++ b/frontend/apps/pos-app/src/app/core/api/pos-api.service.ts
@@ -3,10 +3,12 @@ import {
   AiSuggestion,
   CartLine,
   MetricCard,
+  OrderSummary,
+  PageResponse,
   ProductSummary,
 } from './pos.models';
 import { signal } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 
 @Injectable({ providedIn: 'root' })
 export class PosApiService {
@@ -111,13 +113,21 @@ export class PosApiService {
     this.cartLines.set([]);
   }
 
-    confirmOrder() {
+  confirmOrder() {
     throw new Error('Method not implemented.');
   }
 
   checkout(request: any) {
   return this.http.post('/api/checkout', request);
 }
+
+  getOrders(page = 0, size = 20) {
+    const params = new HttpParams()
+      .set('page', page)
+      .set('size', size);
+
+    return this.http.get<PageResponse<OrderSummary>>('/api/orders', { params });
+  }
 
   // 🔹 AI suggestions (unchanged)
   getAiSuggestions(): AiSuggestion[] {

--- a/frontend/apps/pos-app/src/app/core/api/pos.models.ts
+++ b/frontend/apps/pos-app/src/app/core/api/pos.models.ts
@@ -23,3 +23,19 @@ export interface AiSuggestion {
   title: string;
   detail: string;
 }
+
+export interface OrderSummary {
+  id: number;
+  totalAmount: number;
+  status: string;
+  createdAt: string;
+  createdByUsername: string;
+}
+
+export interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}

--- a/frontend/apps/pos-app/src/app/features/cart/cart-page.component.css
+++ b/frontend/apps/pos-app/src/app/features/cart/cart-page.component.css
@@ -16,10 +16,10 @@ h2 { margin: 0; }
 
 .empty-cart-container {
   text-align: center;
-  margin-top: 20px;
+  margin-top: 1px;
   background: white;
-  padding: 20px;
-  border-radius: 10px;
+  padding: 40px;
+  border-radius: 25px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 

--- a/frontend/apps/pos-app/src/app/features/cart/cart-page.component.html
+++ b/frontend/apps/pos-app/src/app/features/cart/cart-page.component.html
@@ -1,5 +1,5 @@
 <section class="page">
-  <p  class="eyebrow">Cart</p>
+  <h1  class="eyebrow">Cart</h1>
 
   <ng-container *ngIf="lines().length; else emptyCart">
     <article class="card" *ngFor="let line of lines()">

--- a/frontend/apps/pos-app/src/app/features/orders/orders-page.component.css
+++ b/frontend/apps/pos-app/src/app/features/orders/orders-page.component.css
@@ -1,0 +1,86 @@
+.page {
+  display: grid;
+  gap: 1rem;
+}
+
+.hero,
+.order-card,
+.state-card {
+  background: white;
+  border-radius: 22px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.hero {
+  padding: 1.5rem;
+}
+
+.eyebrow,
+.label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.75rem;
+}
+
+.eyebrow {
+  color: #0284c7;
+}
+
+.hero h1 {
+  margin: 0.35rem 0 0.5rem;
+  font-size: 2rem;
+  color: #0f172a;
+}
+
+.subcopy,
+.label {
+  color: #64748b;
+}
+
+.order-card {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  padding: 1.25rem;
+  align-items: center;
+}
+
+.order-main strong,
+.order-total strong {
+  color: #0f172a;
+  font-size: 1.1rem;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 88px;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0369a1;
+  font-weight: 700;
+}
+
+.state-card {
+  padding: 1.5rem;
+  text-align: center;
+  color: #334155;
+}
+
+.state-card.error {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+.btn {
+  border: 0;
+  border-radius: 999px;
+  background: #0f172a;
+  color: white;
+  padding: 0.7rem 1.3rem;
+  cursor: pointer;
+}

--- a/frontend/apps/pos-app/src/app/features/orders/orders-page.component.html
+++ b/frontend/apps/pos-app/src/app/features/orders/orders-page.component.html
@@ -1,0 +1,59 @@
+<section class="page">
+  <header class="hero">
+    <p class="eyebrow">Orders</p>
+    <h1>Recent order activity</h1>
+    <p class="subcopy">Track completed checkouts and see who created each order.</p>
+  </header>
+
+  <ng-container *ngIf="isLoading(); else ordersState">
+    <article class="state-card">
+      <p>Loading orders...</p>
+    </article>
+  </ng-container>
+
+  <ng-template #ordersState>
+    <ng-container *ngIf="!errorMessage(); else errorState">
+      <ng-container *ngIf="orders().length; else emptyState">
+        <article class="order-card" *ngFor="let order of orders()">
+          <div class="order-main">
+            <p class="label">Order ID</p>
+            <strong>#{{ order.id }}</strong>
+          </div>
+
+          <div>
+            <p class="label">Created By</p>
+            <span>{{ order.createdByUsername || 'Unknown' }}</span>
+          </div>
+
+          <div>
+            <p class="label">Status</p>
+            <span class="status">{{ order.status }}</span>
+          </div>
+
+          <div class="order-total">
+            <p class="label">Total</p>
+            <strong>{{ order.totalAmount | currency }}</strong>
+          </div>
+
+          <div class="order-date">
+            <p class="label">Created At</p>
+            <span>{{ order.createdAt | date: 'medium' }}</span>
+          </div>
+        </article>
+      </ng-container>
+    </ng-container>
+  </ng-template>
+
+  <ng-template #errorState>
+    <article class="state-card error">
+      <p>{{ errorMessage() }}</p>
+      <button class="btn" type="button" (click)="loadOrders()">Retry</button>
+    </article>
+  </ng-template>
+
+  <ng-template #emptyState>
+    <article class="state-card">
+      <p>No orders found yet.</p>
+    </article>
+  </ng-template>
+</section>

--- a/frontend/apps/pos-app/src/app/features/orders/orders-page.component.ts
+++ b/frontend/apps/pos-app/src/app/features/orders/orders-page.component.ts
@@ -1,0 +1,40 @@
+import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { PosApiService } from '../../core/api/pos-api.service';
+import { OrderSummary } from '../../core/api/pos.models';
+
+@Component({
+  selector: 'app-orders-page',
+  standalone: true,
+  imports: [CommonModule, CurrencyPipe, DatePipe],
+  templateUrl: './orders-page.component.html',
+  styleUrls: ['./orders-page.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OrdersPageComponent {
+  private readonly api = inject(PosApiService);
+
+  protected readonly orders = signal<OrderSummary[]>([]);
+  protected readonly isLoading = signal(true);
+  protected readonly errorMessage = signal('');
+
+  constructor() {
+    this.loadOrders();
+  }
+
+  protected loadOrders(): void {
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+
+    this.api.getOrders().subscribe({
+      next: (response) => {
+        this.orders.set(response.content ?? []);
+        this.isLoading.set(false);
+      },
+      error: () => {
+        this.errorMessage.set('Unable to load orders right now.');
+        this.isLoading.set(false);
+      },
+    });
+  }
+}

--- a/infra/keycloak/import/ai-pos-realm-copy.json
+++ b/infra/keycloak/import/ai-pos-realm-copy.json
@@ -54,7 +54,7 @@
       "protocol": "openid-connect",
       "publicClient": true,
       "standardFlowEnabled": true,
-      "directAccessGrantsEnabled": false,
+      "directAccessGrantsEnabled": true,
       "implicitFlowEnabled": false,
       "serviceAccountsEnabled": false,
       "redirectUris": [

--- a/infra/keycloak/import/ai-pos-realm.json
+++ b/infra/keycloak/import/ai-pos-realm.json
@@ -54,7 +54,7 @@
       "protocol": "openid-connect",
       "publicClient": true,
       "standardFlowEnabled": true,
-      "directAccessGrantsEnabled": false,
+      "directAccessGrantsEnabled": true,
       "implicitFlowEnabled": false,
       "serviceAccountsEnabled": false,
       "redirectUris": [

--- a/postman/.postman/resources.yaml
+++ b/postman/.postman/resources.yaml
@@ -5,6 +5,9 @@ workspace:
 localResources:
   collections:
     - ../ai-pos-saas-local.postman_collection.json
+    - ../ai-pos-saas-e2e-local.postman_collection.json
+  environments:
+    - ../ai-pos-saas-e2e-local.postman_environment.json
 
 # Each entry here maps a local resource to one or more corresponding objects in Postman Cloud
 cloudResources:

--- a/postman/ai-pos-saas-e2e-local.postman_collection.json
+++ b/postman/ai-pos-saas-e2e-local.postman_collection.json
@@ -1,0 +1,935 @@
+{
+  "info": {
+    "_postman_id": "3d0ed18e-8938-43d4-a8bc-3b5682334684",
+    "name": "AI POS SaaS E2E Local",
+    "description": "End-to-end backend collection for AI POS SaaS. Import and select the `AI POS SaaS E2E Local` environment before running the collection. The local Keycloak realm import must have direct access grants enabled for `pos-client` so Postman can obtain user tokens for the automated flow.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [],
+  "item": [
+    {
+      "name": "00 One-Time Setup",
+      "item": [
+        {
+          "name": "Health",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Health endpoint returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Health endpoint reports UP\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.status).to.eql(\"UP\");",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/actuator/health",
+              "host": ["{{baseUrl}}"],
+              "path": ["actuator", "health"]
+            }
+          }
+        },
+        {
+          "name": "Auth Status",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Auth status returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Auth status exposes Keycloak metadata\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.data.provider).to.eql(\"keycloak\");",
+                  "  pm.expect(json.data.realm).to.eql(pm.variables.get(\"realm\"));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/status",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "auth", "status"]
+            }
+          }
+        },
+        {
+          "name": "Register Tenant Admin",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Register tenant admin returns success or already-exists response\", function () {",
+                  "  pm.expect([200, 409]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{tenantAdminEmail}}\",\n  \"password\": \"{{tenantAdminPassword}}\",\n  \"tenantName\": \"{{tenantName}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/register",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "auth", "register"]
+            }
+          }
+        },
+        {
+          "name": "Tenant Admin Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Tenant admin login returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Tenant admin login returns an access token\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.access_token).to.be.a(\"string\").and.not.empty;",
+                  "  pm.environment.set(\"tenantAdminToken\", json.access_token);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "grant_type=password&client_id={{clientId}}&scope=openid%20profile%20email%20roles%20tenant&username={{tenantAdminEmail}}&password={{tenantAdminPassword}}"
+            },
+            "url": {
+              "raw": "{{keycloakBaseUrl}}/realms/{{realm}}/protocol/openid-connect/token",
+              "host": ["{{keycloakBaseUrl}}"],
+              "path": ["realms", "{{realm}}", "protocol", "openid-connect", "token"]
+            }
+          }
+        },
+        {
+          "name": "Tenant Admin Auth Me",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Tenant admin auth/me returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Tenant admin auth/me returns expected tenant admin user\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.email).to.eql(pm.variables.get(\"tenantAdminEmail\"));",
+                  "  pm.expect(json.roles).to.include(\"TENANT_ADMIN\");",
+                  "  pm.expect(json.tenantId).to.be.a(\"string\").and.not.empty;",
+                  "",
+                  "  pm.environment.set(\"tenantId\", json.tenantId);",
+                  "  pm.environment.set(\"tenantAdminUserId\", json.subject);",
+                  "  pm.environment.set(\"tenantAdminUsername\", json.username);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/me",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "auth", "me"]
+            }
+          }
+        },
+        {
+          "name": "Create Cashier",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Create cashier returns success or a duplicate-friendly error\", function () {",
+                  "  pm.expect([200, 201, 400, 409, 502]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{cashierEmail}}\",\n  \"password\": \"{{cashierPassword}}\",\n  \"firstName\": \"Malar\",\n  \"lastName\": \"Cashier\",\n  \"role\": \"CASHIER\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/users",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "users"]
+            }
+          }
+        },
+        {
+          "name": "Cashier Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Cashier login returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Cashier login returns an access token\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.access_token).to.be.a(\"string\").and.not.empty;",
+                  "  pm.environment.set(\"cashierToken\", json.access_token);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "grant_type=password&client_id={{clientId}}&scope=openid%20profile%20email%20roles%20tenant&username={{cashierEmail}}&password={{cashierPassword}}"
+            },
+            "url": {
+              "raw": "{{keycloakBaseUrl}}/realms/{{realm}}/protocol/openid-connect/token",
+              "host": ["{{keycloakBaseUrl}}"],
+              "path": ["realms", "{{realm}}", "protocol", "openid-connect", "token"]
+            }
+          }
+        },
+        {
+          "name": "Cashier Auth Me",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Cashier auth/me returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Cashier auth/me returns expected cashier user\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.email).to.eql(pm.variables.get(\"cashierEmail\"));",
+                  "  pm.expect(json.roles).to.include(\"CASHIER\");",
+                  "  pm.expect(json.tenantId).to.eql(pm.environment.get(\"tenantId\"));",
+                  "",
+                  "  pm.environment.set(\"cashierUserId\", json.subject);",
+                  "  pm.environment.set(\"cashierUsername\", json.username);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{cashierToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/me",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "auth", "me"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "10 Repeatable Business Flow",
+      "item": [
+        {
+          "name": "Tenant Admin Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Repeatable tenant admin login returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.environment.set(\"tenantAdminToken\", json.access_token);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "grant_type=password&client_id={{clientId}}&scope=openid%20profile%20email%20roles%20tenant&username={{tenantAdminEmail}}&password={{tenantAdminPassword}}"
+            },
+            "url": {
+              "raw": "{{keycloakBaseUrl}}/realms/{{realm}}/protocol/openid-connect/token",
+              "host": ["{{keycloakBaseUrl}}"],
+              "path": ["realms", "{{realm}}", "protocol", "openid-connect", "token"]
+            }
+          }
+        },
+        {
+          "name": "Create Product 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Create product 1 returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Create product 1 returns a product id\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.id).to.not.eql(null);",
+                  "  pm.environment.set(\"product1Id\", String(json.id));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Filter Coffee\",\n  \"category\": \"Beverages\",\n  \"price\": 25.00,\n  \"stockQuantity\": 100\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/products",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "products"]
+            }
+          }
+        },
+        {
+          "name": "Create Product 2",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Create product 2 returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Create product 2 returns a product id\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.id).to.not.eql(null);",
+                  "  pm.environment.set(\"product2Id\", String(json.id));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Masala Tea\",\n  \"category\": \"Beverages\",\n  \"price\": 20.00,\n  \"stockQuantity\": 100\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/products",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "products"]
+            }
+          }
+        },
+        {
+          "name": "List Products",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"List products returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"List products contains the created products\", function () {",
+                  "  const json = pm.response.json();",
+                  "  const ids = json.map(product => String(product.id));",
+                  "  pm.expect(ids).to.include(pm.environment.get(\"product1Id\"));",
+                  "  pm.expect(ids).to.include(pm.environment.get(\"product2Id\"));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/products",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "products"]
+            }
+          }
+        },
+        {
+          "name": "Cashier Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Repeatable cashier login returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.environment.set(\"cashierToken\", json.access_token);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "grant_type=password&client_id={{clientId}}&scope=openid%20profile%20email%20roles%20tenant&username={{cashierEmail}}&password={{cashierPassword}}"
+            },
+            "url": {
+              "raw": "{{keycloakBaseUrl}}/realms/{{realm}}/protocol/openid-connect/token",
+              "host": ["{{keycloakBaseUrl}}"],
+              "path": ["realms", "{{realm}}", "protocol", "openid-connect", "token"]
+            }
+          }
+        },
+        {
+          "name": "Cashier Only",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Cashier-only endpoint returns 200 for cashier\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{cashierToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/cashier/only",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "cashier", "only"]
+            }
+          }
+        },
+        {
+          "name": "Checkout",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Checkout returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Checkout completes the order\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.orderId).to.be.a(\"number\");",
+                  "  pm.expect(json.status).to.eql(\"COMPLETED\");",
+                  "  pm.expect(json.items).to.have.length(2);",
+                  "  pm.environment.set(\"orderId\", String(json.orderId));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{cashierToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"items\": [\n    {\n      \"productId\": {{product1Id}},\n      \"quantity\": 2\n    },\n    {\n      \"productId\": {{product2Id}},\n      \"quantity\": 1\n    }\n  ],\n  \"paymentType\": \"CASH\",\n  \"amountPaid\": 100.00,\n  \"createdByUserId\": \"{{cashierUserId}}\",\n  \"createdByUsername\": \"{{cashierUsername}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/checkout",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "checkout"]
+            }
+          }
+        },
+        {
+          "name": "Order History",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Order history returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Order history contains the created order\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.content).to.be.an(\"array\");",
+                  "",
+                  "  const order = json.content.find(item => String(item.id) === pm.environment.get(\"orderId\"));",
+                  "  pm.expect(order, \"Expected order id to be present in order history\").to.exist;",
+                  "  pm.expect(order.createdByUsername).to.eql(pm.environment.get(\"cashierUsername\"));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{cashierToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/orders?page=0&size=20",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "orders"],
+              "query": [
+                { "key": "page", "value": "0" },
+                { "key": "size", "value": "20" }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "20 Full Endpoint Coverage",
+      "item": [
+        {
+          "name": "Admin Only",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Admin-only endpoint returns 200 for tenant admin\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/admin/only",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "admin", "only"]
+            }
+          }
+        },
+        {
+          "name": "Cashier Only",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Cashier-only endpoint returns 200 for cashier\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{cashierToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/cashier/only",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "cashier", "only"]
+            }
+          }
+        },
+        {
+          "name": "Tenant Current - Admin",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Tenant current returns 200 for tenant admin\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Tenant current returns the expected tenant id\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.tenant_id).to.eql(pm.environment.get(\"tenantId\"));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/tenant/current",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "tenant", "current"]
+            }
+          }
+        },
+        {
+          "name": "Tenant Current - Cashier",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Tenant current returns 200 for cashier\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Cashier tenant current returns the expected tenant id\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.tenant_id).to.eql(pm.environment.get(\"tenantId\"));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{cashierToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/tenant/current",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "tenant", "current"]
+            }
+          }
+        },
+        {
+          "name": "Debug Me - Admin",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Debug me returns 200 for tenant admin\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Debug me returns tenant admin context\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.email).to.eql(pm.variables.get(\"tenantAdminEmail\"));",
+                  "  pm.expect(json.tenant_id).to.eql(pm.environment.get(\"tenantId\"));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/debug/me",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "debug", "me"]
+            }
+          }
+        },
+        {
+          "name": "Debug Me - Cashier",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Debug me returns 200 for cashier\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Debug me returns cashier context\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.email).to.eql(pm.variables.get(\"cashierEmail\"));",
+                  "  pm.expect(json.tenant_id).to.eql(pm.environment.get(\"tenantId\"));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{cashierToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/debug/me",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "debug", "me"]
+            }
+          }
+        },
+        {
+          "name": "Products - Update Product 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Update product returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Update product returns updated details\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(String(json.id)).to.eql(pm.environment.get(\"product1Id\"));",
+                  "  pm.expect(json.name).to.eql(\"Filter Coffee Large\");",
+                  "  pm.expect(Number(json.stockQuantity)).to.eql(120);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Filter Coffee Large\",\n  \"category\": \"Beverages\",\n  \"price\": 30.00,\n  \"stockQuantity\": 120\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/products/{{product1Id}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "products", "{{product1Id}}"]
+            }
+          }
+        },
+        {
+          "name": "Products - Deactivate Product 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Deactivate product returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/products/{{product1Id}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "products", "{{product1Id}}"]
+            }
+          }
+        },
+        {
+          "name": "Products - Activate Product 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Activate product returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/products/{{product1Id}}/activate",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "products", "{{product1Id}}", "activate"]
+            }
+          }
+        },
+        {
+          "name": "Products - List",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Product list returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Product list still contains both created products\", function () {",
+                  "  const json = pm.response.json();",
+                  "  const ids = json.map(product => String(product.id));",
+                  "  pm.expect(ids).to.include(pm.environment.get(\"product1Id\"));",
+                  "  pm.expect(ids).to.include(pm.environment.get(\"product2Id\"));",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/products",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "products"]
+            }
+          }
+        },
+        {
+          "name": "AI Chat",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"AI chat returns 200\", function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"AI chat returns the scaffold response shape\", function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.message).to.be.a(\"string\");",
+                  "  pm.expect(json.data.message).to.be.a(\"string\");",
+                  "  pm.expect(json.data.userPrompt).to.eql(\"Show low stock items\");",
+                  "  pm.expect(json.data.suggestedActions).to.be.an(\"array\");",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{tenantAdminToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"message\": \"Show low stock items\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/ai/chat",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ai", "chat"]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/postman/ai-pos-saas-e2e-local.postman_environment.json
+++ b/postman/ai-pos-saas-e2e-local.postman_environment.json
@@ -1,0 +1,29 @@
+{
+  "id": "9a39ec27-a23f-49d3-bacb-44dd4f607aa3",
+  "name": "AI POS SaaS E2E Local",
+  "values": [
+    { "key": "baseUrl", "value": "http://localhost:8080", "enabled": true },
+    { "key": "keycloakBaseUrl", "value": "http://localhost:8081", "enabled": true },
+    { "key": "keycloakAdminBaseUrl", "value": "http://localhost:8081", "enabled": true },
+    { "key": "realm", "value": "ai-pos", "enabled": true },
+    { "key": "clientId", "value": "pos-client", "enabled": true },
+    { "key": "tenantAdminEmail", "value": "admin@malar.com", "enabled": true },
+    { "key": "tenantAdminPassword", "value": "Password1", "enabled": true },
+    { "key": "tenantName", "value": "malar.com", "enabled": true },
+    { "key": "cashierEmail", "value": "malar@malar.com", "enabled": true },
+    { "key": "cashierPassword", "value": "Password1", "enabled": true },
+    { "key": "tenantAdminToken", "value": "", "enabled": true },
+    { "key": "cashierToken", "value": "", "enabled": true },
+    { "key": "tenantId", "value": "", "enabled": true },
+    { "key": "tenantAdminUserId", "value": "", "enabled": true },
+    { "key": "tenantAdminUsername", "value": "", "enabled": true },
+    { "key": "cashierUserId", "value": "", "enabled": true },
+    { "key": "cashierUsername", "value": "", "enabled": true },
+    { "key": "product1Id", "value": "", "enabled": true },
+    { "key": "product2Id", "value": "", "enabled": true },
+    { "key": "orderId", "value": "", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2026-03-27T00:00:00.000Z",
+  "_postman_exported_using": "OpenAI Codex"
+}

--- a/postman/postman/collections/AI POS Auth Test Collection/Admin - Only.request.yaml
+++ b/postman/postman/collections/AI POS Auth Test Collection/Admin - Only.request.yaml
@@ -1,6 +1,18 @@
 $kind: http-request
-url: "{{baseUrl}}/api/admin/only"
+url: '{{baseUrl}}/api/admin/only'
 method: GET
 headers:
-  Authorization: Bearer {{access_token}}
+  - key: Authorization
+    value: 'Bearer {{access_token}}'
 order: 5000
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status is 200 - admin has access", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Response body is not empty", function () {
+        pm.expect(pm.response.text()).to.not.be.empty;
+      });

--- a/postman/postman/collections/AI POS Auth Test Collection/Auth - Register.request.yaml
+++ b/postman/postman/collections/AI POS Auth Test Collection/Auth - Register.request.yaml
@@ -1,10 +1,11 @@
 $kind: http-request
-url: "{{baseUrl}}/api/auth/register"
+url: '{{baseUrl}}/api/auth/register'
 method: POST
 headers:
-  Content-Type: application/json
+  - key: Content-Type
+    value: application/json
 body:
-  type: text
+  type: json
   content: |-
     {
       "email": "test@ai-pos.local",
@@ -12,3 +13,26 @@ body:
       "tenantName": "Test Store"
     }
 order: 2000
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status is 200 or 201", function () {
+        pm.expect(pm.response.code).to.be.oneOf([200, 201]);
+      });
+
+      pm.test("Response has a JSON body", function () {
+        pm.response.to.be.json;
+      });
+
+      pm.test("Response contains an access token", function () {
+        const json = pm.response.json();
+        const token = json.access_token || json.token;
+        pm.expect(token, "Expected access_token or token field in response").to.be.a("string").and.not.empty;
+
+        if (json.access_token) {
+          pm.collectionVariables.set("access_token", json.access_token);
+        } else if (json.token) {
+          pm.collectionVariables.set("access_token", json.token);
+        }
+      });

--- a/postman/postman/collections/AI POS Auth Test Collection/Auth - Status.request.yaml
+++ b/postman/postman/collections/AI POS Auth Test Collection/Auth - Status.request.yaml
@@ -1,4 +1,25 @@
 $kind: http-request
-url: "{{baseUrl}}/api/auth/status"
+url: '{{baseUrl}}/api/auth/status'
 method: GET
 order: 1000
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status is 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Response has a JSON body", function () {
+        pm.response.to.be.json;
+      });
+
+      pm.test("Response contains a status or health indicator field", function () {
+        const json = pm.response.json();
+        const hasStatus = json.hasOwnProperty("status") ||
+                          json.hasOwnProperty("health") ||
+                          json.hasOwnProperty("ok") ||
+                          json.hasOwnProperty("message") ||
+                          json.hasOwnProperty("alive");
+        pm.expect(hasStatus, "Expected a status/health indicator field in response").to.be.true;
+      });

--- a/postman/postman/collections/AI POS Auth Test Collection/Cashier - Only.request.yaml
+++ b/postman/postman/collections/AI POS Auth Test Collection/Cashier - Only.request.yaml
@@ -1,6 +1,18 @@
 $kind: http-request
-url: "{{baseUrl}}/api/cashier/only"
+url: '{{baseUrl}}/api/cashier/only'
 method: GET
 headers:
-  Authorization: Bearer {{access_token}}
+  - key: Authorization
+    value: 'Bearer {{access_token}}'
 order: 6000
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status is 200 - cashier has access", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Response body is not empty", function () {
+        pm.expect(pm.response.text()).to.not.be.empty;
+      });

--- a/postman/postman/collections/AI POS Auth Test Collection/Debug - Me.request.yaml
+++ b/postman/postman/collections/AI POS Auth Test Collection/Debug - Me.request.yaml
@@ -1,6 +1,29 @@
 $kind: http-request
-url: "{{baseUrl}}/api/debug/me"
+url: '{{baseUrl}}/api/debug/me'
 method: GET
 headers:
-  Authorization: Bearer {{access_token}}
+  - key: Authorization
+    value: 'Bearer {{access_token}}'
 order: 3000
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status is 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Response has a JSON body", function () {
+        pm.response.to.be.json;
+      });
+
+      pm.test("Response contains user identity info", function () {
+        const json = pm.response.json();
+        const hasIdentity = json.hasOwnProperty("email") ||
+                            json.hasOwnProperty("id") ||
+                            json.hasOwnProperty("userId") ||
+                            json.hasOwnProperty("role") ||
+                            json.hasOwnProperty("tenantId") ||
+                            json.hasOwnProperty("user");
+        pm.expect(hasIdentity, "Expected user identity fields (email, id, role, tenantId, or user) in response").to.be.true;
+      });

--- a/postman/postman/collections/AI POS Auth Test Collection/Tenant - Current.request.yaml
+++ b/postman/postman/collections/AI POS Auth Test Collection/Tenant - Current.request.yaml
@@ -1,6 +1,28 @@
 $kind: http-request
-url: "{{baseUrl}}/api/tenant/current"
+url: '{{baseUrl}}/api/tenant/current'
 method: GET
 headers:
-  Authorization: Bearer {{access_token}}
+  - key: Authorization
+    value: 'Bearer {{access_token}}'
 order: 4000
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status is 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Response has a JSON body", function () {
+        pm.response.to.be.json;
+      });
+
+      pm.test("Response contains tenant info", function () {
+        const json = pm.response.json();
+        const hasTenantInfo = json.hasOwnProperty("id") ||
+                              json.hasOwnProperty("tenantId") ||
+                              json.hasOwnProperty("name") ||
+                              json.hasOwnProperty("tenantName") ||
+                              json.hasOwnProperty("tenant");
+        pm.expect(hasTenantInfo, "Expected tenant info fields (id, tenantId, name, tenantName, or tenant) in response").to.be.true;
+      });

--- a/postman/postman/collections/AI POS Auth Test Collection/User - Provisioning.request.yaml
+++ b/postman/postman/collections/AI POS Auth Test Collection/User - Provisioning.request.yaml
@@ -1,12 +1,14 @@
 $kind: http-request
 name: User - Provisioning
-url: "{{baseUrl}}/api/users"
+url: '{{baseUrl}}/api/users'
 method: POST
 headers:
-  Content-Type: application/json
-  Authorization: Bearer {{access_token}}
+  - key: Content-Type
+    value: application/json
+  - key: Authorization
+    value: 'Bearer {{access_token}}'
 body:
-  type: text
+  type: json
   content: |-
     {
       "email": "anbu1@ai-pos.local",
@@ -14,3 +16,25 @@ body:
       "tenantName": "Test Store"
     }
 order: 2156
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status is 200 or 201", function () {
+        pm.expect(pm.response.code).to.be.oneOf([200, 201]);
+      });
+
+      pm.test("Response has a JSON body", function () {
+        pm.response.to.be.json;
+      });
+
+      pm.test("Response contains user info or success message", function () {
+        const json = pm.response.json();
+        const hasUserOrSuccess = json.hasOwnProperty("id") ||
+                                 json.hasOwnProperty("userId") ||
+                                 json.hasOwnProperty("email") ||
+                                 json.hasOwnProperty("user") ||
+                                 json.hasOwnProperty("message") ||
+                                 json.hasOwnProperty("success");
+        pm.expect(hasUserOrSuccess, "Expected user info or success message in response").to.be.true;
+      });

--- a/postman/postman/collections/AI POS Auth Test Collection/auth - Me.request.yaml
+++ b/postman/postman/collections/AI POS Auth Test Collection/auth - Me.request.yaml
@@ -1,8 +1,30 @@
 $kind: http-request
 name: auth - Me
-url: "{{baseUrl}}/api/auth/me"
+url: '{{baseUrl}}/api/auth/me'
 method: GET
 headers:
   - key: Authorization
-    value: Bearer {{access_token}}
+    value: 'Bearer {{access_token}}'
 order: 3235
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status is 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Response has a JSON body", function () {
+        pm.response.to.be.json;
+      });
+
+      pm.test("Response contains user info", function () {
+        const json = pm.response.json();
+        const hasUserInfo = json.hasOwnProperty("email") ||
+                            json.hasOwnProperty("id") ||
+                            json.hasOwnProperty("userId") ||
+                            json.hasOwnProperty("role") ||
+                            json.hasOwnProperty("tenantId") ||
+                            json.hasOwnProperty("user");
+        pm.expect(hasUserInfo, "Expected user info fields (email, id, role, tenantId, or user) in response").to.be.true;
+      });

--- a/postman/postman/collections/AI POS Auth Test Collection/collection.yaml
+++ b/postman/postman/collections/AI POS Auth Test Collection/collection.yaml
@@ -1,0 +1,7 @@
+$kind: collection
+name: AI POS Auth Test Collection
+variables:
+  - key: baseUrl
+    value: 'http://localhost:8080'
+  - key: access_token
+    value: ''

--- a/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/.resources/definition.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 1000

--- a/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Auth Status.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Auth Status.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+name: Auth Status
+url: "{{baseUrl}}/api/auth/status"
+method: GET
+order: 1100
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Auth status returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Auth status exposes Keycloak metadata", function () {
+        const json = pm.response.json();
+        pm.expect(json.data.provider).to.eql("keycloak");
+        pm.expect(json.data.realm).to.eql(pm.variables.get("realm"));
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Cashier Auth Me.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Cashier Auth Me.request.yaml
@@ -1,0 +1,25 @@
+$kind: http-request
+name: Cashier Auth Me
+url: "{{baseUrl}}/api/auth/me"
+method: GET
+headers:
+  - key: Authorization
+    value: Bearer {{cashierToken}}
+order: 1800
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Cashier auth/me returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Cashier auth/me returns expected cashier user", function () {
+        const json = pm.response.json();
+        pm.expect(json.email).to.eql(pm.variables.get("cashierEmail"));
+        pm.expect(json.roles).to.include("CASHIER");
+        pm.expect(json.tenantId).to.eql(pm.environment.get("tenantId"));
+
+        pm.environment.set("cashierUserId", json.subject);
+        pm.environment.set("cashierUsername", json.username);
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Cashier Login.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Cashier Login.request.yaml
@@ -1,0 +1,23 @@
+$kind: http-request
+name: Cashier Login
+url: "{{keycloakBaseUrl}}/realms/{{realm}}/protocol/openid-connect/token"
+method: POST
+headers:
+  Content-Type: application/x-www-form-urlencoded
+body:
+  type: text
+  content: grant_type=password&client_id={{clientId}}&username={{cashierEmail}}&password={{cashierPassword}}
+order: 1700
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test("Cashier login returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Cashier login returns an access token", function () {
+        const json = pm.response.json();
+        pm.expect(json.access_token).to.be.a("string").and.not.empty;
+        pm.environment.set("cashierToken", json.access_token);
+      });
+    language: text/javascript

--- a/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Create Cashier.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Create Cashier.request.yaml
@@ -1,0 +1,27 @@
+$kind: http-request
+name: Create Cashier
+url: "{{baseUrl}}/api/users"
+method: POST
+headers:
+  - key: Content-Type
+    value: application/json
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+body:
+  type: json
+  content: |-
+    {
+      "email": "{{cashierEmail}}",
+      "password": "{{cashierPassword}}",
+      "firstName": "Malar",
+      "lastName": "Cashier",
+      "role": "CASHIER"
+    }
+order: 1600
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Create cashier returns success or a duplicate-friendly error", function () {
+        pm.expect([200, 201, 400, 409, 502]).to.include(pm.response.code);
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Health.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Health.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+name: Health
+url: "{{baseUrl}}/actuator/health"
+method: GET
+order: 1000
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Health endpoint returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Health endpoint reports UP", function () {
+        const json = pm.response.json();
+        pm.expect(json.status).to.eql("UP");
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Register Tenant Admin.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Register Tenant Admin.request.yaml
@@ -1,0 +1,23 @@
+$kind: http-request
+name: Register Tenant Admin
+url: "{{baseUrl}}/api/auth/register"
+method: POST
+headers:
+  - key: Content-Type
+    value: application/json
+body:
+  type: json
+  content: |-
+    {
+      "email": "{{tenantAdminEmail}}",
+      "password": "{{tenantAdminPassword}}",
+      "tenantName": "{{tenantName}}"
+    }
+order: 1300
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Register tenant admin returns success or already-exists response", function () {
+        pm.expect([200, 409]).to.include(pm.response.code);
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Tenant Admin Auth Me.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Tenant Admin Auth Me.request.yaml
@@ -1,0 +1,26 @@
+$kind: http-request
+name: Tenant Admin Auth Me
+url: "{{baseUrl}}/api/auth/me"
+method: GET
+headers:
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+order: 1500
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Tenant admin auth/me returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Tenant admin auth/me returns expected tenant admin user", function () {
+        const json = pm.response.json();
+        pm.expect(json.email).to.eql(pm.variables.get("tenantAdminEmail"));
+        pm.expect(json.roles).to.include("TENANT_ADMIN");
+        pm.expect(json.tenantId).to.be.a("string").and.not.empty;
+
+        pm.environment.set("tenantId", json.tenantId);
+        pm.environment.set("tenantAdminUserId", json.subject);
+        pm.environment.set("tenantAdminUsername", json.username);
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Tenant Admin Login.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/00 One-Time Setup/Tenant Admin Login.request.yaml
@@ -1,0 +1,23 @@
+$kind: http-request
+name: Tenant Admin Login
+url: "{{keycloakBaseUrl}}/realms/{{realm}}/protocol/openid-connect/token"
+method: POST
+headers:
+  Content-Type: application/x-www-form-urlencoded
+body:
+  type: text
+  content: grant_type=password&client_id={{clientId}}&scope=profile%20email%20roles%20tenant&username={{tenantAdminEmail}}&password={{tenantAdminPassword}}
+order: 1400
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test("Tenant admin login returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Tenant admin login returns an access token", function () {
+        const json = pm.response.json();
+        pm.expect(json.access_token).to.be.a("string").and.not.empty;
+        pm.environment.set("tenantAdminToken", json.access_token);
+      });
+    language: text/javascript

--- a/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/.resources/definition.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 2000

--- a/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Cashier Login.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Cashier Login.request.yaml
@@ -1,0 +1,20 @@
+$kind: http-request
+name: Cashier Login
+url: "{{keycloakBaseUrl}}/realms/{{realm}}/protocol/openid-connect/token"
+method: POST
+headers:
+  Content-Type: application/x-www-form-urlencoded
+body:
+  type: text
+  content: grant_type=password&client_id={{clientId}}&username={{cashierEmail}}&password={{cashierPassword}}
+order: 1400
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test("Repeatable cashier login returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      const json = pm.response.json();
+      pm.environment.set("cashierToken", json.access_token);
+    language: text/javascript

--- a/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Cashier Only.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Cashier Only.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+name: Cashier Only
+url: "{{baseUrl}}/api/cashier/only"
+method: GET
+headers:
+  - key: Authorization
+    value: Bearer {{cashierToken}}
+order: 1500
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Cashier-only endpoint returns 200 for cashier", function () {
+        pm.response.to.have.status(200);
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Checkout.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Checkout.request.yaml
@@ -1,0 +1,44 @@
+$kind: http-request
+name: Checkout
+url: "{{baseUrl}}/api/checkout"
+method: POST
+headers:
+  - key: Content-Type
+    value: application/json
+  - key: Authorization
+    value: Bearer {{cashierToken}}
+body:
+  type: json
+  content: |-
+    {
+      "items": [
+        {
+          "productId": {{product1Id}},
+          "quantity": 2
+        },
+        {
+          "productId": {{product2Id}},
+          "quantity": 1
+        }
+      ],
+      "paymentType": "CASH",
+      "amountPaid": 100.00,
+      "createdByUserId": "{{cashierUserId}}",
+      "createdByUsername": "{{cashierUsername}}"
+    }
+order: 1600
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Checkout returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Checkout completes the order", function () {
+        const json = pm.response.json();
+        pm.expect(json.orderId).to.be.a("number");
+        pm.expect(json.status).to.eql("COMPLETED");
+        pm.expect(json.items).to.have.length(2);
+        pm.environment.set("orderId", String(json.orderId));
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Create Product 1.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Create Product 1.request.yaml
@@ -1,0 +1,32 @@
+$kind: http-request
+name: Create Product 1
+url: "{{baseUrl}}/api/products"
+method: POST
+headers:
+  - key: Content-Type
+    value: application/json
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+body:
+  type: json
+  content: |-
+    {
+      "name": "Filter Coffee",
+      "category": "Beverages",
+      "price": 25.00,
+      "stockQuantity": 100
+    }
+order: 1100
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Create product 1 returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Create product 1 returns a product id", function () {
+        const json = pm.response.json();
+        pm.expect(json.id).to.not.eql(null);
+        pm.environment.set("product1Id", String(json.id));
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Create Product 2.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Create Product 2.request.yaml
@@ -1,0 +1,32 @@
+$kind: http-request
+name: Create Product 2
+url: "{{baseUrl}}/api/products"
+method: POST
+headers:
+  - key: Content-Type
+    value: application/json
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+body:
+  type: json
+  content: |-
+    {
+      "name": "Masala Tea",
+      "category": "Beverages",
+      "price": 20.00,
+      "stockQuantity": 100
+    }
+order: 1200
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Create product 2 returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Create product 2 returns a product id", function () {
+        const json = pm.response.json();
+        pm.expect(json.id).to.not.eql(null);
+        pm.environment.set("product2Id", String(json.id));
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/List Products.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/List Products.request.yaml
@@ -1,0 +1,22 @@
+$kind: http-request
+name: List Products
+url: "{{baseUrl}}/api/products"
+method: GET
+headers:
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+order: 1300
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("List products returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("List products contains the created products", function () {
+        const json = pm.response.json();
+        const ids = json.map(product => String(product.id));
+        pm.expect(ids).to.include(pm.environment.get("product1Id"));
+        pm.expect(ids).to.include(pm.environment.get("product2Id"));
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Order History.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Order History.request.yaml
@@ -1,0 +1,24 @@
+$kind: http-request
+name: Order History
+url: "{{baseUrl}}/api/orders?page=0&size=20"
+method: GET
+headers:
+  - key: Authorization
+    value: Bearer {{cashierToken}}
+order: 1700
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Order history returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Order history contains the created order", function () {
+        const json = pm.response.json();
+        pm.expect(json.content).to.be.an("array");
+
+        const order = json.content.find(item => String(item.id) === pm.environment.get("orderId"));
+        pm.expect(order, "Expected order id to be present in order history").to.exist;
+        pm.expect(order.createdByUsername).to.eql(pm.environment.get("cashierUsername"));
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Tenant Admin Login.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/10 Repeatable Business Flow/Tenant Admin Login.request.yaml
@@ -1,0 +1,20 @@
+$kind: http-request
+name: Tenant Admin Login
+url: "{{keycloakBaseUrl}}/realms/{{realm}}/protocol/openid-connect/token"
+method: POST
+headers:
+  Content-Type: application/x-www-form-urlencoded
+body:
+  type: text
+  content: grant_type=password&client_id={{clientId}}&username={{tenantAdminEmail}}&password={{tenantAdminPassword}}
+order: 1000
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test("Repeatable tenant admin login returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      const json = pm.response.json();
+      pm.environment.set("tenantAdminToken", json.access_token);
+    language: text/javascript

--- a/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/.resources/definition.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 3000

--- a/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/AI Chat.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/AI Chat.request.yaml
@@ -1,0 +1,31 @@
+$kind: http-request
+name: AI Chat
+url: "{{baseUrl}}/api/ai/chat"
+method: POST
+headers:
+  - key: Content-Type
+    value: application/json
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+body:
+  type: json
+  content: |-
+    {
+      "message": "Show low stock items"
+    }
+order: 2000
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("AI chat returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("AI chat returns the scaffold response shape", function () {
+        const json = pm.response.json();
+        pm.expect(json.message).to.be.a("string");
+        pm.expect(json.data.message).to.be.a("string");
+        pm.expect(json.data.userPrompt).to.eql("Show low stock items");
+        pm.expect(json.data.suggestedActions).to.be.an("array");
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Admin Only.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Admin Only.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+name: Admin Only
+url: "{{baseUrl}}/api/admin/only"
+method: GET
+headers:
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+order: 1000
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Admin-only endpoint returns 200 for tenant admin", function () {
+        pm.response.to.have.status(200);
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Cashier Only.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Cashier Only.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+name: Cashier Only
+url: "{{baseUrl}}/api/cashier/only"
+method: GET
+headers:
+  - key: Authorization
+    value: Bearer {{cashierToken}}
+order: 1100
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Cashier-only endpoint returns 200 for cashier", function () {
+        pm.response.to.have.status(200);
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Debug Me - Admin.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Debug Me - Admin.request.yaml
@@ -1,0 +1,21 @@
+$kind: http-request
+name: Debug Me - Admin
+url: "{{baseUrl}}/api/debug/me"
+method: GET
+headers:
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+order: 1400
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Debug me returns 200 for tenant admin", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Debug me returns tenant admin context", function () {
+        const json = pm.response.json();
+        pm.expect(json.email).to.eql(pm.variables.get("tenantAdminEmail"));
+        pm.expect(json.tenant_id).to.eql(pm.environment.get("tenantId"));
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Debug Me - Cashier.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Debug Me - Cashier.request.yaml
@@ -1,0 +1,21 @@
+$kind: http-request
+name: Debug Me - Cashier
+url: "{{baseUrl}}/api/debug/me"
+method: GET
+headers:
+  - key: Authorization
+    value: Bearer {{cashierToken}}
+order: 1500
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Debug me returns 200 for cashier", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Debug me returns cashier context", function () {
+        const json = pm.response.json();
+        pm.expect(json.email).to.eql(pm.variables.get("cashierEmail"));
+        pm.expect(json.tenant_id).to.eql(pm.environment.get("tenantId"));
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Products - Activate Product 1.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Products - Activate Product 1.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+name: Products - Activate Product 1
+url: "{{baseUrl}}/api/products/{{product1Id}}/activate"
+method: PUT
+headers:
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+order: 1800
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Activate product returns 200", function () {
+        pm.response.to.have.status(200);
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Products - Deactivate Product 1.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Products - Deactivate Product 1.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+name: Products - Deactivate Product 1
+url: "{{baseUrl}}/api/products/{{product1Id}}"
+method: DELETE
+headers:
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+order: 1700
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Deactivate product returns 200", function () {
+        pm.response.to.have.status(200);
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Products - List.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Products - List.request.yaml
@@ -1,0 +1,22 @@
+$kind: http-request
+name: Products - List
+url: "{{baseUrl}}/api/products"
+method: GET
+headers:
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+order: 1900
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Product list returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Product list still contains both created products", function () {
+        const json = pm.response.json();
+        const ids = json.map(product => String(product.id));
+        pm.expect(ids).to.include(pm.environment.get("product1Id"));
+        pm.expect(ids).to.include(pm.environment.get("product2Id"));
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Products - Update Product 1.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Products - Update Product 1.request.yaml
@@ -1,0 +1,33 @@
+$kind: http-request
+name: Products - Update Product 1
+url: "{{baseUrl}}/api/products/{{product1Id}}"
+method: PUT
+headers:
+  - key: Content-Type
+    value: application/json
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+body:
+  type: json
+  content: |-
+    {
+      "name": "Filter Coffee Large",
+      "category": "Beverages",
+      "price": 30.00,
+      "stockQuantity": 120
+    }
+order: 1600
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Update product returns 200", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Update product returns updated details", function () {
+        const json = pm.response.json();
+        pm.expect(String(json.id)).to.eql(pm.environment.get("product1Id"));
+        pm.expect(json.name).to.eql("Filter Coffee Large");
+        pm.expect(Number(json.stockQuantity)).to.eql(120);
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Tenant Current - Admin.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Tenant Current - Admin.request.yaml
@@ -1,0 +1,20 @@
+$kind: http-request
+name: Tenant Current - Admin
+url: "{{baseUrl}}/api/tenant/current"
+method: GET
+headers:
+  - key: Authorization
+    value: Bearer {{tenantAdminToken}}
+order: 1200
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Tenant current returns 200 for tenant admin", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Tenant current returns the expected tenant id", function () {
+        const json = pm.response.json();
+        pm.expect(json.tenant_id).to.eql(pm.environment.get("tenantId"));
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Tenant Current - Cashier.request.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/20 Full Endpoint Coverage/Tenant Current - Cashier.request.yaml
@@ -1,0 +1,20 @@
+$kind: http-request
+name: Tenant Current - Cashier
+url: "{{baseUrl}}/api/tenant/current"
+method: GET
+headers:
+  - key: Authorization
+    value: Bearer {{cashierToken}}
+order: 1300
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Tenant current returns 200 for cashier", function () {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test("Cashier tenant current returns the expected tenant id", function () {
+        const json = pm.response.json();
+        pm.expect(json.tenant_id).to.eql(pm.environment.get("tenantId"));
+      });

--- a/postman/postman/collections/AI POS SaaS E2E Local/collection.yaml
+++ b/postman/postman/collections/AI POS SaaS E2E Local/collection.yaml
@@ -1,0 +1,7 @@
+$kind: collection
+name: AI POS SaaS E2E Local
+description: >-
+  End-to-end backend collection for AI POS SaaS. Import and select the `AI POS
+  SaaS E2E Local` environment before running the collection. The local Keycloak
+  realm import must have direct access grants enabled for `pos-client` so
+  Postman can obtain user tokens for the automated flow.

--- a/postman/postman/collections/AI POS SaaS Local/Backend/Order/Orders.request.yaml
+++ b/postman/postman/collections/AI POS SaaS Local/Backend/Order/Orders.request.yaml
@@ -1,0 +1,21 @@
+$kind: http-request
+name: Orders
+url: "{{baseUrl}}/api/orders"
+method: POST
+headers:
+  Content-Type: application/json
+  Authorization: Bearer {{access_token}}
+body:
+  type: text
+  content: |-
+    {
+      "items": [
+        {
+          "productId": 3,
+          "quantity": 2
+        }
+      ],
+      "paymentType": "CASH",
+      "amountPaid": 15000.00
+    }
+order: 2385667612054471

--- a/postman/postman/environments/AI POS SaaS E2E Local.environment.yaml
+++ b/postman/postman/environments/AI POS SaaS E2E Local.environment.yaml
@@ -1,0 +1,63 @@
+name: AI POS SaaS E2E Local
+values:
+  - key: baseUrl
+    value: 'http://localhost:8080'
+    enabled: true
+  - key: keycloakBaseUrl
+    value: 'http://localhost:8081'
+    enabled: true
+  - key: keycloakAdminBaseUrl
+    value: 'http://localhost:8081'
+    enabled: true
+  - key: realm
+    value: ai-pos
+    enabled: true
+  - key: clientId
+    value: pos-client
+    enabled: true
+  - key: tenantAdminEmail
+    value: admin@malar.com
+    enabled: true
+  - key: tenantAdminPassword
+    value: Password1
+    enabled: true
+  - key: tenantName
+    value: malar.com
+    enabled: true
+  - key: cashierEmail
+    value: malar@malar.com
+    enabled: true
+  - key: cashierPassword
+    value: Password1
+    enabled: true
+  - key: tenantAdminToken
+    value: ''
+    enabled: true
+  - key: cashierToken
+    value: ''
+    enabled: true
+  - key: tenantId
+    value: ''
+    enabled: true
+  - key: tenantAdminUserId
+    value: ''
+    enabled: true
+  - key: tenantAdminUsername
+    value: ''
+    enabled: true
+  - key: cashierUserId
+    value: ''
+    enabled: true
+  - key: cashierUsername
+    value: ''
+    enabled: true
+  - key: product1Id
+    value: ''
+    enabled: true
+  - key: product2Id
+    value: ''
+    enabled: true
+  - key: orderId
+    value: ''
+    enabled: true
+color: 240

--- a/postman/postman/globals/workspace.globals.yaml
+++ b/postman/postman/globals/workspace.globals.yaml
@@ -1,2 +1,17 @@
 name: Globals
-values: []
+values:
+  - key: baseUrl
+    value: 'http://localhost:8080'
+    enabled: true
+  - key: keycloakBaseUrl
+    value: 'http://localhost:8081'
+    enabled: true
+  - key: keycloakAdminBaseUrl
+    value: 'http://localhost:8081'
+    enabled: true
+  - key: realm
+    value: ai-pos
+    enabled: true
+  - key: clientId
+    value: pos-client
+    enabled: true


### PR DESCRIPTION
## Summary
- add backend order history query support and controller wiring
- add POS frontend orders page and API models/routes
- expand local Postman collections for order history and end-to-end flows